### PR TITLE
5 define enums

### DIFF
--- a/src/models/JobLikeState.ts
+++ b/src/models/JobLikeState.ts
@@ -1,0 +1,5 @@
+export enum JobLikeState {
+  None = 'None',
+  Liked = 'Liked',
+  Disliked = 'Disliked',
+}

--- a/src/models/JobStatus.ts
+++ b/src/models/JobStatus.ts
@@ -1,0 +1,18 @@
+export enum JobStatus {
+  // Application sent
+  Applied = 'Applied',
+  // Company response
+  UnderReview = 'UnderReview',
+  Shortlisted = 'Shortlisted',
+  Rejected = 'Rejected',
+  // Recruitment process
+  InterviewPlanned = 'InterviewPlanned',
+  InterviewDone = 'InterviewDone',
+  InterviewCanceled = 'InterviewCanceled',
+  OfferMade = 'OfferMade',
+  Negotiation = 'Negotiation',
+  OfferAccepted = 'OfferAccepted',
+  OfferDeclined = 'OfferDeclined',
+  // Closure
+  Hired = 'Hired',
+}

--- a/src/models/__tests__/JobLikeState.spec.ts
+++ b/src/models/__tests__/JobLikeState.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { JobLikeState } from '../JobLikeState';
+
+describe('JobLikeState enum', () => {
+  it('should have correct values', () => {
+    expect(JobLikeState.None).toBe('None');
+    expect(JobLikeState.Liked).toBe('Liked');
+    expect(JobLikeState.Disliked).toBe('Disliked');
+  });
+});

--- a/src/models/__tests__/JobStatus.spec.ts
+++ b/src/models/__tests__/JobStatus.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { JobStatus } from '../JobStatus';
+
+describe('JobStatus enum', () => {
+  it('should have correct values', () => {
+    expect(JobStatus.Applied).toBe('Applie');
+    expect(JobStatus.UnderReview).toBe('UnderReview');
+    expect(JobStatus.Shortlisted).toBe('Shortlisted');
+    expect(JobStatus.Rejected).toBe('Rejected');
+    expect(JobStatus.InterviewPlanned).toBe('InterviewPlanned');
+    expect(JobStatus.InterviewDone).toBe('InterviewDone');
+    expect(JobStatus.InterviewCanceled).toBe('InterviewCanceled');
+    expect(JobStatus.OfferMade).toBe('OfferMade');
+    expect(JobStatus.Negotiation).toBe('Negotiation');
+    expect(JobStatus.OfferAccepted).toBe('OfferAccepted');
+    expect(JobStatus.OfferDeclined).toBe('OfferDeclined');
+    expect(JobStatus.Hired).toBe('Hired');
+  });
+});

--- a/src/models/__tests__/JobStatus.spec.ts
+++ b/src/models/__tests__/JobStatus.spec.ts
@@ -3,7 +3,7 @@ import { JobStatus } from '../JobStatus';
 
 describe('JobStatus enum', () => {
   it('should have correct values', () => {
-    expect(JobStatus.Applied).toBe('Applie');
+    expect(JobStatus.Applied).toBe('Applied');
     expect(JobStatus.UnderReview).toBe('UnderReview');
     expect(JobStatus.Shortlisted).toBe('Shortlisted');
     expect(JobStatus.Rejected).toBe('Rejected');


### PR DESCRIPTION
This pull request introduces two new enums, `JobLikeState` and `JobStatus`, to represent job-related states and statuses in the application. It also adds corresponding unit tests to ensure these enums have the correct values.

Enum additions:

* Added a new `JobLikeState` enum with values: `None`, `Liked`, and `Disliked` in `JobLikeState.ts`.
* Added a new `JobStatus` enum with various job application statuses such as `Applied`, `UnderReview`, `Shortlisted`, `Rejected`, and others in `JobStatus.ts`.

Testing:

* Added unit tests for `JobLikeState` to verify its values in `JobLikeState.spec.ts`.
* Added unit tests for `JobStatus` to verify its values in `JobStatus.spec.ts` (note: there is a typo in the expected value for `Applied`—should be `'Applied'` instead of `'Applie'`).