### PR TITLE
3 job model

### DIFF
--- a/src/models/Job.schema.ts
+++ b/src/models/Job.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { JobStatus } from './JobStatus';
+import { JobLikeState } from './JobLikeState';
+
+export const JobSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1),
+  city: z.string().min(1),
+  remote: z.boolean(),
+  salary: z.number().nonnegative(),
+  status: z.enum(JobStatus),
+  like: z.enum(JobLikeState),
+});
+
+export type JobType = z.infer<typeof JobSchema>;

--- a/src/models/JobSanitizer.ts
+++ b/src/models/JobSanitizer.ts
@@ -26,8 +26,8 @@ export class JobSanitizer {
       city: dataSanitized.city || '',
       remote: typeof dataSanitized.remote === 'boolean' ? dataSanitized.remote : false,
       salary: typeof dataSanitized.salary === 'number' ? dataSanitized.salary : 0,
-      status: dataSanitized.status!,
-      like: dataSanitized.like!,
+      status: dataSanitized.status || JobStatus.None,
+      like: dataSanitized.like || JobLikeState.None,
     };
   }
 }

--- a/src/models/JobSanitizer.ts
+++ b/src/models/JobSanitizer.ts
@@ -1,0 +1,33 @@
+import sanitizeHtml from 'sanitize-html';
+import type { JobType } from './Job.schema';
+import { JobLikeState } from './JobLikeState';
+import { JobStatus } from './JobStatus';
+
+const SANITIZE_STRICT_CONFIG = { allowedTags: [], allowedAttributes: {} };
+export class JobSanitizer {
+  static partialSanitize(data: Partial<JobType>): Partial<JobType> {
+    const dataSanitized: Partial<JobType> = {
+      id: data.id ? sanitizeHtml(data.id, SANITIZE_STRICT_CONFIG) : undefined,
+      title: data.title ? sanitizeHtml(data.title, SANITIZE_STRICT_CONFIG) : undefined,
+      city: data.city ? sanitizeHtml(data.city, SANITIZE_STRICT_CONFIG) : undefined,
+      remote: typeof data.remote === 'boolean' ? data.remote : undefined,
+      salary: typeof data.salary === 'number' ? data.salary : undefined,
+      status: (data.status && Object.values(JobStatus).includes(data.status)) ? data.status : undefined,
+      like: (data.like && Object.values(JobLikeState).includes(data.like)) ? data.like : undefined,
+    };
+    return dataSanitized;
+  }
+
+  static sanitize(data: JobType): JobType {
+    const dataSanitized = this.partialSanitize(data);
+    return {
+      id: dataSanitized.id || '',
+      title: dataSanitized.title || '',
+      city: dataSanitized.city || '',
+      remote: typeof dataSanitized.remote === 'boolean' ? dataSanitized.remote : false,
+      salary: typeof dataSanitized.salary === 'number' ? dataSanitized.salary : 0,
+      status: dataSanitized.status!,
+      like: dataSanitized.like!,
+    };
+  }
+}

--- a/src/models/JobStatus.ts
+++ b/src/models/JobStatus.ts
@@ -1,4 +1,5 @@
 export enum JobStatus {
+  None = 'None',
   // Application sent
   Applied = 'Applied',
   // Company response

--- a/src/models/__tests__/Job.schema.spec.ts
+++ b/src/models/__tests__/Job.schema.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { JobSchema } from '../Job.schema';
+import { JobStatus } from '../JobStatus';
+import { JobLikeState } from '../JobLikeState';
+
+const validJob = {
+  id: 'job-1',
+  title: 'Développeur',
+  city: 'Paris',
+  remote: true,
+  salary: 45000,
+  status: JobStatus.Applied,
+  like: JobLikeState.None,
+};
+
+describe('JobSchema', () => {
+  it('should validate a correct job object', () => {
+    const result = JobSchema.safeParse(validJob);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with empty id', () => {
+    const job = { ...validJob, id: '' };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with liked state', () => {
+    const job = { ...validJob, like: JobLikeState.Liked };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with disliked state', () => {
+    const job = { ...validJob, like: JobLikeState.Disliked };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status UnderReview', () => {
+    const job = { ...validJob, status: JobStatus.UnderReview };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status Shortlisted', () => {
+    const job = { ...validJob, status: JobStatus.Shortlisted };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status Rejected', () => {
+    const job = { ...validJob, status: JobStatus.Rejected };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status InterviewPlanned', () => {
+    const job = { ...validJob, status: JobStatus.InterviewPlanned };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status InterviewDone', () => {
+    const job = { ...validJob, status: JobStatus.InterviewDone };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status InterviewCanceled', () => {
+    const job = { ...validJob, status: JobStatus.InterviewCanceled };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status OfferMade', () => {
+    const job = { ...validJob, status: JobStatus.OfferMade };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status Negotiation', () => {
+    const job = { ...validJob, status: JobStatus.Negotiation };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status OfferAccepted', () => {
+    const job = { ...validJob, status: JobStatus.OfferAccepted };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status OfferDeclined', () => {
+    const job = { ...validJob, status: JobStatus.OfferDeclined };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status Hired', () => {
+    const job = { ...validJob, status: JobStatus.Hired };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject a job with empty title', () => {
+    const job = { ...validJob, title: '' };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a job with negative salary', () => {
+    const job = { ...validJob, salary: -1000 };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a job with invalid status', () => {
+    const job = { ...validJob, status: 'Unknown' };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a job with invalid like value', () => {
+    const job = { ...validJob, like: 'SuperLiked' };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a job with empty city', () => {
+    const job = { ...validJob, city: '' };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a job with wrong types', () => {
+    const job = { ...validJob, salary: 'high' };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/models/__tests__/Job.schema.spec.ts
+++ b/src/models/__tests__/Job.schema.spec.ts
@@ -9,7 +9,7 @@ const validJob = {
   city: 'Paris',
   remote: true,
   salary: 45000,
-  status: JobStatus.Applied,
+  status: JobStatus.None,
   like: JobLikeState.None,
 };
 
@@ -33,6 +33,12 @@ describe('JobSchema', () => {
 
   it('should validate a job with disliked state', () => {
     const job = { ...validJob, like: JobLikeState.Disliked };
+    const result = JobSchema.safeParse(job);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a job with status Applied', () => {
+    const job = { ...validJob, status: JobStatus.Applied };
     const result = JobSchema.safeParse(job);
     expect(result.success).toBe(true);
   });

--- a/src/models/__tests__/JobSanitizer.spec.ts
+++ b/src/models/__tests__/JobSanitizer.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { JobSanitizer } from '../JobSanitizer';
+import { JobStatus } from '../JobStatus';
+import { JobLikeState } from '../JobLikeState';
+import type { JobType } from '../Job.schema';
+
+const dirtyJob: Partial<JobType> = {
+  id: '<script>alert(1)</script><b>job-1</b><img src=x onerror=alert(1)/>',
+  title: '<script>alert(1)</script><b>Developer</b><img src=x onerror=alert(1)/>',
+  city: '<script>alert(1)</script><b>Paris</b><img src=x onerror=alert(1)/>',
+  remote: true,
+  salary: 50000,
+  status: JobStatus.Applied,
+  like: JobLikeState.Liked,
+};
+
+describe('JobSanitizer', () => {
+  it('should sanitize all string fields', () => {
+    const sanitized = JobSanitizer.sanitize(dirtyJob as JobType);
+    expect(sanitized.id).toBe('job-1');
+    expect(sanitized.title).toBe('Developer');
+    expect(sanitized.city).toBe('Paris');
+  });
+
+  it('should keep valid boolean and number fields', () => {
+    const sanitized = JobSanitizer.sanitize(dirtyJob as JobType);
+    expect(sanitized.remote).toBe(true);
+    expect(sanitized.salary).toBe(50000);
+  });
+
+  it('should keep valid enum values', () => {
+    const sanitized = JobSanitizer.sanitize(dirtyJob as JobType);
+    expect(sanitized.status).toBe(JobStatus.Applied);
+    expect(sanitized.like).toBe(JobLikeState.Liked);
+  });
+
+  it('should fallback to defaults for missing or invalid fields', () => {
+    const partial: Partial<JobType> = { };
+    const sanitized = JobSanitizer.sanitize(partial as JobType);
+    expect(sanitized.id).toBe('');
+    expect(sanitized.title).toBe('');
+    expect(sanitized.city).toBe('');
+    expect(sanitized.remote).toBe(false);
+    expect(sanitized.salary).toBe(0);
+  });
+
+  it('should reject invalid enum status value', () => {
+    const partial: Partial<JobType> = {
+      ...dirtyJob,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      status: '<script>alert(1)</script><b>NotAStatus</b><img src=x onerror=alert(1)/>' as any,
+    };
+    const sanitized = JobSanitizer.sanitize(partial as JobType);
+    expect(Object.values(JobStatus)).not.toContain(sanitized.status);
+  });
+
+  it('should reject invalid enum like value', () => {
+    const partial: Partial<JobType> = {
+      ...dirtyJob,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      like: '<script>alert(1)</script><b>SuperLiked</b><img src=x onerror=alert(1)/>' as any,
+    };
+    const sanitized = JobSanitizer.sanitize(partial as JobType);
+    expect(Object.values(JobLikeState)).not.toContain(sanitized.like);
+  });
+});

--- a/src/models/__tests__/JobSanitizer.spec.ts
+++ b/src/models/__tests__/JobSanitizer.spec.ts
@@ -51,7 +51,7 @@ describe('JobSanitizer', () => {
       status: '<script>alert(1)</script><b>NotAStatus</b><img src=x onerror=alert(1)/>' as any,
     };
     const sanitized = JobSanitizer.sanitize(partial as JobType);
-    expect(Object.values(JobStatus)).not.toContain(sanitized.status);
+    expect(Object.values(JobStatus)).toContain(sanitized.status);
   });
 
   it('should reject invalid enum like value', () => {
@@ -61,6 +61,6 @@ describe('JobSanitizer', () => {
       like: '<script>alert(1)</script><b>SuperLiked</b><img src=x onerror=alert(1)/>' as any,
     };
     const sanitized = JobSanitizer.sanitize(partial as JobType);
-    expect(Object.values(JobLikeState)).not.toContain(sanitized.like);
+    expect(Object.values(JobLikeState)).toContain(sanitized.like);
   });
 });

--- a/src/models/__tests__/JobStatus.spec.ts
+++ b/src/models/__tests__/JobStatus.spec.ts
@@ -3,6 +3,7 @@ import { JobStatus } from '../JobStatus';
 
 describe('JobStatus enum', () => {
   it('should have correct values', () => {
+    expect(JobStatus.None).toBe('None');
     expect(JobStatus.Applied).toBe('Applied');
     expect(JobStatus.UnderReview).toBe('UnderReview');
     expect(JobStatus.Shortlisted).toBe('Shortlisted');


### PR DESCRIPTION
This pull request introduces a new validation and sanitization system for job data, ensuring that job objects conform to expected types and values and that any potentially unsafe input is cleaned. It also adds comprehensive unit tests for both the schema and the sanitizer to guarantee correct behavior and robustness.

**Job schema and validation:**

* Added `JobSchema` using Zod to define and validate the structure of job objects, including fields like `id`, `title`, `city`, `remote`, `salary`, `status`, and `like`. Also exported the inferred `JobType` type.

**Sanitization logic:**

* Introduced `JobSanitizer` class to sanitize job data, removing unwanted HTML from string fields and validating enum and primitive values. Provided methods for both full and partial sanitization.

**Testing:**

* Added unit tests for `JobSchema` to verify correct validation, including acceptance of valid data and rejection of invalid or malformed job objects.
* Added unit tests for `JobSanitizer` to ensure string sanitization, correct handling of valid and invalid enum values, and proper fallback to defaults for missing or invalid fields.