### PR TITLE
31 implement company repository

### DIFF
--- a/src/data/companies.seed.json
+++ b/src/data/companies.seed.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "1",
+    "name": "Tech Innovators",
+    "location": "Paris, France",
+    "size": 120,
+    "industry": "Software"
+  },
+  {
+    "id": "2",
+    "name": "Green Solutions",
+    "location": "Lyon, France",
+    "size": 45,
+    "industry": "Environmental"
+  },
+  {
+    "id": "3",
+    "name": "HealthFirst",
+    "location": "Marseille, France",
+    "size": 200,
+    "industry": "Healthcare"
+  },
+  {
+    "id": "4",
+    "name": "EduSmart",
+    "location": "Toulouse, France",
+    "size": 80,
+    "industry": "Education"
+  },
+  {
+    "id": "5",
+    "name": "FinTech Pro",
+    "location": "Nice, France",
+    "size": 60,
+    "industry": "Finance"
+  }
+]

--- a/src/repositories/CompanyRepository.ts
+++ b/src/repositories/CompanyRepository.ts
@@ -33,8 +33,10 @@ export class CompanyRepository {
    */
   async getById(id: string): Promise<CompanyType> {
     if (!id) throw new GetCompanyByIdError();
+
     const company = this.companies.find(c => c.id === id);
     if (!company) throw new GetCompanyByIdError();
+
     try {
       return CompanySchema.parse(company);
     } catch {
@@ -51,11 +53,14 @@ export class CompanyRepository {
   async updatePartial(id: string, update: Partial<CompanyType>): Promise<CompanyType> {
     if (!id) throw new UpdateCompanyError();
     if (!update || Object.keys(update).length === 0) throw new UpdateCompanyError();
+
     const index = this.companies.findIndex(c => c.id === id);
     if (index === -1) throw new UpdateCompanyError();
+
     try {
       const merged = { ...this.companies[index], ...update };
-      const validated = CompanySchema.parse(merged);
+      const sanitized = CompanySanitizer.sanitize(merged);
+      const validated = CompanySchema.parse(sanitized);
       this.companies[index] = validated;
       return validated;
     } catch {

--- a/src/repositories/CompanyRepository.ts
+++ b/src/repositories/CompanyRepository.ts
@@ -1,0 +1,64 @@
+import companiesSeed from '../data/companies.seed.json';
+import { CompanySchema } from '@/models/Company.schema';
+import type { CompanyType } from '@/models/Company.schema';
+import { GetAllCompaniesError, GetCompanyByIdError, UpdateCompanyError } from './errors/CompanyRepositoryError';
+
+export class CompanyRepository {
+  private companies: CompanyType[];
+
+  constructor() {
+    // Initialize the in-memory companies array
+    this.companies = CompanySchema.array().parse(
+      companiesSeed as unknown as CompanyType[]
+    );
+  }
+
+  /**
+   * Returns the complete list of companies
+   * @throws {GetAllCompaniesError} If an unexpected error occurs
+   */
+  async list(): Promise<CompanyType[]> {
+    try {
+      return this.companies.map((c) => CompanySchema.parse(c));
+    } catch {
+      throw new GetAllCompaniesError();
+    }
+  }
+
+  /**
+   * Returns a company by its id
+   * @param id Id of the company
+   * @throws {GetCompanyByIdError} If id is missing, not found, or validation fails
+   */
+  async getById(id: string): Promise<CompanyType> {
+    if (!id) throw new GetCompanyByIdError();
+    const company = this.companies.find(c => c.id === id);
+    if (!company) throw new GetCompanyByIdError();
+    try {
+      return CompanySchema.parse(company);
+    } catch {
+      throw new GetCompanyByIdError();
+    }
+  }
+
+  /**
+   * Partially updates a company (shallow merge)
+   * @param id Id of the company
+   * @param update Partial fields to update
+   * @throws {UpdateCompanyError} If id or update is missing, not found, or validation fails
+   */
+  async updatePartial(id: string, update: Partial<CompanyType>): Promise<CompanyType> {
+    if (!id) throw new UpdateCompanyError();
+    if (!update || Object.keys(update).length === 0) throw new UpdateCompanyError();
+    const index = this.companies.findIndex(c => c.id === id);
+    if (index === -1) throw new UpdateCompanyError();
+    try {
+      const merged = { ...this.companies[index], ...update };
+      const validated = CompanySchema.parse(merged);
+      this.companies[index] = validated;
+      return validated;
+    } catch {
+      throw new UpdateCompanyError();
+    }
+  }
+}

--- a/src/repositories/CompanyRepository.ts
+++ b/src/repositories/CompanyRepository.ts
@@ -2,6 +2,7 @@ import companiesSeed from '../data/companies.seed.json';
 import { CompanySchema } from '@/models/Company.schema';
 import type { CompanyType } from '@/models/Company.schema';
 import { GetAllCompaniesError, GetCompanyByIdError, UpdateCompanyError } from './errors/CompanyRepositoryError';
+import { CompanySanitizer } from '@/models/CompanySanitizer';
 
 export class CompanyRepository {
   private companies: CompanyType[];
@@ -9,7 +10,7 @@ export class CompanyRepository {
   constructor() {
     // Initialize the in-memory companies array
     this.companies = CompanySchema.array().parse(
-      companiesSeed as unknown as CompanyType[]
+      (companiesSeed as unknown as CompanyType[]).map(c => CompanySanitizer.sanitize(c))
     );
   }
 

--- a/src/repositories/__tests__/CompanyRepository.spec.ts
+++ b/src/repositories/__tests__/CompanyRepository.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CompanyRepository } from '../CompanyRepository';
+import { GetAllCompaniesError, GetCompanyByIdError, UpdateCompanyError } from '../errors/CompanyRepositoryError';
+import companiesSeed from '../../data/companies.seed.json';
+
+const validId = companiesSeed[0].id;
+const invalidId = 'not-found-id';
+const createRepo = () => new CompanyRepository();
+
+describe('CompanyRepository', () => {
+  let repo: CompanyRepository;
+  beforeEach(() => {
+    repo = createRepo();
+  });
+
+  it('list() returns all companies', async () => {
+    const companies = await repo.list();
+    expect(Array.isArray(companies)).toBe(true);
+    expect(companies.length).toBe(companiesSeed.length);
+    expect(companies[0]).toHaveProperty('id');
+    expect(companies[0]).toHaveProperty('name');
+  });
+
+  it('getById() returns a company by id', async () => {
+    const company = await repo.getById(validId);
+    expect(company).toBeDefined();
+    expect(company.id).toBe(validId);
+  });
+
+  it('getById() throws if id not found', async () => {
+    await expect(repo.getById(invalidId)).rejects.toThrow(GetCompanyByIdError);
+  });
+
+  it('updatePartial() updates a company field', async () => {
+    const newName = 'Updated Name';
+    const updated = await repo.updatePartial(validId, { name: newName });
+    expect(updated.name).toBe(newName);
+    const fetched = await repo.getById(validId);
+    expect(fetched.name).toBe(newName);
+  });
+
+  it('updatePartial() throws if id not found', async () => {
+    await expect(repo.updatePartial(invalidId, { name: 'X' })).rejects.toThrow(UpdateCompanyError);
+  });
+
+  it('updatePartial() throws if update is empty', async () => {
+    await expect(repo.updatePartial(validId, {})).rejects.toThrow(UpdateCompanyError);
+  });
+
+  it('list() throws GetAllCompaniesError on internal error', async () => {
+    // Simulate internal corruption
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    repo.companies = null;
+    await expect(repo.list()).rejects.toThrow(GetAllCompaniesError);
+  });
+});

--- a/src/repositories/__tests__/CompanyRepository.spec.ts
+++ b/src/repositories/__tests__/CompanyRepository.spec.ts
@@ -39,6 +39,35 @@ describe('CompanyRepository', () => {
     expect(fetched.name).toBe(newName);
   });
 
+  it('updatePartial() with injected code in name', async () => {
+    const maliciousUpdate = { name: '<script>alert("xss")</script>' };
+    await expect(repo.updatePartial(validId, maliciousUpdate)).rejects.toThrow(UpdateCompanyError);
+  });
+
+  it('updatePartial() with injected code in location', async () => {
+    const maliciousUpdate = { location: '<img src=x onerror=alert("xss") />' };
+    const updated = await repo.updatePartial(validId, maliciousUpdate);
+    expect(updated.location).toBe('');
+    const fetched = await repo.getById(validId);
+    expect(fetched.location).toBe('');
+  });
+
+  it('updatePartial() with injected code in size', async () => {
+    const maliciousUpdate = { size: '<script>alert("xss")</script>' as unknown as number };
+    const updated = await repo.updatePartial(validId, maliciousUpdate);
+    expect(updated.size).toBe(0);
+    const fetched = await repo.getById(validId);
+    expect(fetched.size).toBe(0);
+  });
+
+  it('updatePartial() with injected code in industry', async () => {
+    const maliciousUpdate = { industry: '<iframe src="javascript:alert(\'xss\')"></iframe>' };
+    const updated = await repo.updatePartial(validId, maliciousUpdate);
+    expect(updated.industry).toBe('');
+    const fetched = await repo.getById(validId);
+    expect(fetched.industry).toBe('');
+  });
+
   it('updatePartial() throws if id not found', async () => {
     await expect(repo.updatePartial(invalidId, { name: 'X' })).rejects.toThrow(UpdateCompanyError);
   });

--- a/src/repositories/__tests__/CompanyRepository.spec.ts
+++ b/src/repositories/__tests__/CompanyRepository.spec.ts
@@ -3,6 +3,7 @@ import { CompanyRepository } from '../CompanyRepository';
 import { GetAllCompaniesError, GetCompanyByIdError, UpdateCompanyError } from '../errors/CompanyRepositoryError';
 import companiesSeed from '../../data/companies.seed.json';
 
+const HACKER_INJECTION = '<script>alert("xss")</script>';
 const validId = companiesSeed[0].id;
 const invalidId = 'not-found-id';
 const createRepo = () => new CompanyRepository();
@@ -40,12 +41,12 @@ describe('CompanyRepository', () => {
   });
 
   it('updatePartial() with injected code in name', async () => {
-    const maliciousUpdate = { name: '<script>alert("xss")</script>' };
+    const maliciousUpdate = { name: HACKER_INJECTION };
     await expect(repo.updatePartial(validId, maliciousUpdate)).rejects.toThrow(UpdateCompanyError);
   });
 
   it('updatePartial() with injected code in location', async () => {
-    const maliciousUpdate = { location: '<img src=x onerror=alert("xss") />' };
+    const maliciousUpdate = { location: HACKER_INJECTION };
     const updated = await repo.updatePartial(validId, maliciousUpdate);
     expect(updated.location).toBe('');
     const fetched = await repo.getById(validId);
@@ -53,7 +54,7 @@ describe('CompanyRepository', () => {
   });
 
   it('updatePartial() with injected code in size', async () => {
-    const maliciousUpdate = { size: '<script>alert("xss")</script>' as unknown as number };
+    const maliciousUpdate = { size: HACKER_INJECTION as unknown as number };
     const updated = await repo.updatePartial(validId, maliciousUpdate);
     expect(updated.size).toBe(0);
     const fetched = await repo.getById(validId);
@@ -61,7 +62,7 @@ describe('CompanyRepository', () => {
   });
 
   it('updatePartial() with injected code in industry', async () => {
-    const maliciousUpdate = { industry: '<iframe src="javascript:alert(\'xss\')"></iframe>' };
+    const maliciousUpdate = { industry: HACKER_INJECTION };
     const updated = await repo.updatePartial(validId, maliciousUpdate);
     expect(updated.industry).toBe('');
     const fetched = await repo.getById(validId);

--- a/src/repositories/__tests__/JobRepository.spec.ts
+++ b/src/repositories/__tests__/JobRepository.spec.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { JobRepository } from '../JobRepository';
 import { GetAllJobsError, GetJobByIdError, UpdateJobError } from '../errors/JobRepositoryError';
 import jobsSeed from '../../data/jobs.seed.json';
+import { JobStatus } from '@/models/JobStatus';
+import { JobLikeState } from '@/models/JobLikeState';
 
+const HACKER_INJECTION = '<script>alert("xss")</script>';
 const getFirstJobId = () => (jobsSeed[0] as { id: string }).id;
 
 describe('JobRepository', () => {
@@ -42,6 +45,48 @@ describe('JobRepository', () => {
     // Should persist in repo
     const job = await repo.getById(id);
     expect(job.title).toBe(newTitle);
+  });
+
+  it('updatePartial() with injected code in title', async () => {
+    const maliciousUpdate = { title: HACKER_INJECTION };
+    await expect(repo.updatePartial(getFirstJobId(), maliciousUpdate)).rejects.toThrow(UpdateJobError);
+  });
+
+  it('updatePartial() with injected code in city', async () => {
+    const maliciousUpdate = { city: HACKER_INJECTION };
+    await expect(repo.updatePartial(getFirstJobId(), maliciousUpdate)).rejects.toThrow(UpdateJobError);
+  });
+
+  it('updatePartial() with injected code in remote', async () => {
+    const maliciousUpdate = { remote: HACKER_INJECTION as unknown as boolean };
+    const updated = await repo.updatePartial(getFirstJobId(), maliciousUpdate);
+    expect(updated.remote).toBe(false);
+    const fetched = await repo.getById(getFirstJobId());
+    expect(fetched.remote).toBe(false);
+  });
+
+  it('updatePartial() with injected code in salary', async () => {
+    const maliciousUpdate = { salary: HACKER_INJECTION as unknown as number };
+    const updated = await repo.updatePartial(getFirstJobId(), maliciousUpdate);
+    expect(updated.salary).toBe(0);
+    const fetched = await repo.getById(getFirstJobId());
+    expect(fetched.salary).toBe(0);
+  });
+
+  it('updatePartial() with injected code in status', async () => {
+    const maliciousUpdate = { status: HACKER_INJECTION as unknown as JobStatus };
+    const updated = await repo.updatePartial(getFirstJobId(), maliciousUpdate);
+    expect(updated.status).toBe(JobStatus.None);
+    const fetched = await repo.getById(getFirstJobId());
+    expect(fetched.status).toBe(JobStatus.None);
+  });
+
+  it('updatePartial() with injected code in like', async () => {
+    const maliciousUpdate = { like: HACKER_INJECTION as unknown as JobLikeState };
+    const updated = await repo.updatePartial(getFirstJobId(), maliciousUpdate);
+    expect(updated.like).toBe(JobLikeState.None);
+    const fetched = await repo.getById(getFirstJobId());
+    expect(fetched.like).toBe(JobLikeState.None);
   });
 
   it('updatePartial() throws if id is missing', async () => {

--- a/src/repositories/errors/CompanyRepositoryError.ts
+++ b/src/repositories/errors/CompanyRepositoryError.ts
@@ -1,0 +1,27 @@
+export class CompanyRepositoryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CompanyRepositoryError';
+  }
+}
+
+export class GetAllCompaniesError extends CompanyRepositoryError {
+  constructor() {
+    super('Failed to retrieve all companies.');
+    this.name = 'GetAllCompaniesError';
+  }
+}
+
+export class GetCompanyByIdError extends CompanyRepositoryError {
+  constructor() {
+    super('Failed to retrieve company by id.');
+    this.name = 'GetCompanyByIdError';
+  }
+}
+
+export class UpdateCompanyError extends CompanyRepositoryError {
+  constructor() {
+    super('Failed to update company.');
+    this.name = 'UpdateCompanyError';
+  }
+}

--- a/src/repositories/errors/CompanyRepositoryError.ts
+++ b/src/repositories/errors/CompanyRepositoryError.ts
@@ -14,7 +14,7 @@ export class GetAllCompaniesError extends CompanyRepositoryError {
 
 export class GetCompanyByIdError extends CompanyRepositoryError {
   constructor() {
-    super('Failed to retrieve company by id.');
+    super('Company not found with the provided ID.');
     this.name = 'GetCompanyByIdError';
   }
 }


### PR DESCRIPTION
This pull request introduces an in-memory repository for managing company data, complete with robust error handling and comprehensive unit tests. The main changes include seeding company data, implementing the `CompanyRepository` with standard CRUD operations, defining custom error classes, and adding tests to ensure repository reliability.

**Repository and Data Management:**

* Added a new `CompanyRepository` class that manages an in-memory list of companies, supporting listing all companies, retrieving by ID, and partial updates with validation and error handling.
* Introduced a seed data file `companies.seed.json` containing sample company records for use in the repository.

**Error Handling:**

* Created custom error classes (`GetAllCompaniesError`, `GetCompanyByIdError`, `UpdateCompanyError`) to provide clear and specific error messages for repository operations.

**Testing:**

* Added a comprehensive test suite for `CompanyRepository`, covering successful operations, error cases, and edge conditions to ensure robust behavior.