### PR TITLE
7 create jobs service

### DIFF
--- a/src/data/jobs.seed.json
+++ b/src/data/jobs.seed.json
@@ -70,5 +70,23 @@
     "salary": 60000,
     "status": "Hired",
     "like": "Disliked"
+  },
+  {
+    "id": "job-9",
+    "title": "Full Stack Developer",
+    "city": "Strasbourg",
+    "remote": true,
+    "salary": 45000,
+    "status": "Applied",
+    "like": "None"
+  },
+  {
+    "id": "job-10",
+    "title": "System Administrator",
+    "city": "Saint-Étienne",
+    "remote": false,
+    "salary": 40000,
+    "status": "UnderReview",
+    "like": "Liked"
   }
 ]

--- a/src/services/JobsPersistenceService.ts
+++ b/src/services/JobsPersistenceService.ts
@@ -1,0 +1,43 @@
+import { JobLikeState } from '@/models/JobLikeState';
+import { JobStatus } from '@/models/JobStatus';
+
+const LIKES_KEY = 'jobs.likes';
+const STATUSES_KEY = 'jobs.statuses';
+
+export class JobsPersistenceService {
+  static loadLikes(): Record<string, JobLikeState> {
+    try {
+      const raw = localStorage.getItem(LIKES_KEY);
+      if (raw) return JSON.parse(raw) as Record<string, JobLikeState>;
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  static saveLikes(likes: Record<string, JobLikeState>): void {
+    try {
+      localStorage.setItem(LIKES_KEY, JSON.stringify(likes));
+    } catch {
+      // fail silently
+    }
+  }
+
+  static loadStatuses(): Record<string, JobStatus> {
+    try {
+      const raw = localStorage.getItem(STATUSES_KEY);
+      if (raw) return JSON.parse(raw) as Record<string, JobStatus>;
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  static saveStatuses(statuses: Record<string, JobStatus>): void {
+    try {
+      localStorage.setItem(STATUSES_KEY, JSON.stringify(statuses));
+    } catch {
+      // fail silently
+    }
+  }
+}

--- a/src/services/JobsService.ts
+++ b/src/services/JobsService.ts
@@ -1,0 +1,97 @@
+import { useJobsStore } from '@/stores/jobs.store';
+import { JobsPersistenceService } from './JobsPersistenceService';
+import { JobRepository } from '@/repositories/JobRepository';
+import type { JobType } from '@/models/Job.schema';
+import { JobLikeState } from '@/models/JobLikeState';
+import { JobStatus } from '@/models/JobStatus';
+
+export class JobsService {
+  private store = useJobsStore();
+  private repo = new JobRepository();
+
+  // Hydrate store from persistence
+  hydrate() {
+    Object.assign(this.store.likes, JobsPersistenceService.loadLikes());
+    Object.assign(this.store.statuses, JobsPersistenceService.loadStatuses());
+  }
+
+  // Persist likes and statuses
+  persistLikes() {
+    JobsPersistenceService.saveLikes({ ...this.store.likes });
+  }
+  persistStatuses() {
+    JobsPersistenceService.saveStatuses({ ...this.store.statuses });
+  }
+
+  // Load jobs from repo and set in store
+  async loadJobs() {
+    const jobs = await this.repo.list();
+    this.store.setItems(jobs);
+  }
+
+  // Search jobs by text query
+  search(query: string): JobType[] {
+    const q = query.trim().toLowerCase();
+    if (!q) return this.store.items;
+    return this.store.items.filter((j: JobType) =>
+      j.title.toLowerCase().includes(q) ||
+      j.city.toLowerCase().includes(q)
+    );
+  }
+
+  // Filter jobs by city and remote
+  filter(city?: string, remote?: boolean): JobType[] {
+    return this.store.items.filter((j: JobType) => {
+      const cityMatch = city ? j.city === city : true;
+      const remoteMatch = remote === undefined ? true : j.remote === remote;
+      return cityMatch && remoteMatch;
+    });
+  }
+
+  // Calculate interest score for a job
+  interestScore(job: JobType): number {
+    // Like/Dislike: priorité
+    if (job.like === JobLikeState.Disliked) return 0;
+    // Statuts fermés : score nul
+    if (job.status === JobStatus.Rejected || job.status === JobStatus.Hired) return 0;
+
+    let score = 0;
+
+    // Remote
+    if (job.remote) score += 8;
+
+    // Ville
+    if (job.city.toLowerCase().match(/lyon|saint-étienne/i)) score += 6;
+    else score -= 5;
+
+    // Salaire
+    if (job.salary >= 45000) score += 12;
+    else if (job.salary < 35000) score -= 8;
+
+    // Statut avancé
+    if (job.status === JobStatus.InterviewPlanned) score += 15;
+    if (job.status === JobStatus.OfferMade) score += 20;
+
+    // Like
+    if (job.like === JobLikeState.Liked) score += 30;
+
+    return score;
+  }
+
+  // Set like and persist
+  setLike(jobId: string, like: JobLikeState) {
+    this.store.setLike(jobId, like);
+    this.persistLikes();
+  }
+
+  // Set status and persist
+  setStatus(jobId: string, status: JobStatus) {
+    this.store.setStatus(jobId, status);
+    this.persistStatuses();
+  }
+}
+
+// Facade composable
+export function useJobsService() {
+  return new JobsService();
+}

--- a/src/services/JobsService.ts
+++ b/src/services/JobsService.ts
@@ -50,27 +50,28 @@ export class JobsService {
 
   // Calculate interest score for a job
   interestScore(job: JobType): number {
-    // Like/Dislike: priorité
+    // Like/Dislike: priority
     if (job.like === JobLikeState.Disliked) return 0;
-    // Statuts fermés : score nul
-    if (job.status === JobStatus.Rejected || job.status === JobStatus.Hired) return 0;
+    // Closed/negative status: score 0
+    if (job.status === JobStatus.Rejected) return 0;
 
     let score = 0;
 
     // Remote
     if (job.remote) score += 8;
 
-    // Ville
+    // City
     if (job.city.toLowerCase().match(/lyon|saint-étienne/i)) score += 6;
     else score -= 5;
 
-    // Salaire
+    // Salary
     if (job.salary >= 45000) score += 12;
     else if (job.salary < 35000) score -= 8;
 
-    // Statut avancé
+    // Advanced status
     if (job.status === JobStatus.InterviewPlanned) score += 15;
     if (job.status === JobStatus.OfferMade) score += 20;
+    if (job.status === JobStatus.Hired) score += 30;
 
     // Like
     if (job.like === JobLikeState.Liked) score += 30;

--- a/src/services/JobsService.ts
+++ b/src/services/JobsService.ts
@@ -5,6 +5,8 @@ import type { JobType } from '@/models/Job.schema';
 import { JobLikeState } from '@/models/JobLikeState';
 import { JobStatus } from '@/models/JobStatus';
 
+const TARGET_CITIES = ['lyon', 'saint-étienne'];
+
 export class JobsService {
   private store = useJobsStore();
   private repo = new JobRepository();
@@ -61,7 +63,7 @@ export class JobsService {
     if (job.remote) score += 8;
 
     // City
-    if (job.city.toLowerCase().match(/lyon|saint-étienne/i)) score += 6;
+    if (TARGET_CITIES.includes(job.city.toLowerCase())) score += 6;
     else score -= 5;
 
     // Salary

--- a/src/services/JobsService.ts
+++ b/src/services/JobsService.ts
@@ -90,8 +90,3 @@ export class JobsService {
     this.persistStatuses();
   }
 }
-
-// Facade composable
-export function useJobsService() {
-  return new JobsService();
-}

--- a/src/services/__tests__/JobsService.spec.ts
+++ b/src/services/__tests__/JobsService.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { JobsService } from '../JobsService';
+import { JobLikeState } from '@/models/JobLikeState';
+import { JobStatus } from '@/models/JobStatus';
+import type { JobType } from '@/models/Job.schema';
+import jobsSeed from '../../data/jobs.seed.json';
+
+describe('JobsService', () => {
+  let service: JobsService;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    service = new JobsService();
+  });
+
+  function makeJob(overrides: Partial<JobType> = {}): JobType {
+    return {
+      id: '1',
+      title: 'Développeur',
+      city: 'Lyon',
+      remote: true,
+      salary: 50000,
+      status: JobStatus.None,
+      like: JobLikeState.None,
+      ...overrides,
+    };
+  }
+
+  // --- interestScore ---
+  it('score = 0 if disliked', () => {
+    const job = makeJob({ like: JobLikeState.Disliked });
+    expect(service.interestScore(job)).toBe(0);
+  });
+
+  it('score = 0 if status is rejected', () => {
+    const job = makeJob({ status: JobStatus.Rejected });
+    expect(service.interestScore(job)).toBe(0);
+  });
+
+  it('positive score if remote, target city, salary >= 45k, liked', () => {
+    const job = makeJob({ like: JobLikeState.Liked });
+    // remote +8, city +6, salary +12, liked +30
+    expect(service.interestScore(job)).toBe(8 + 6 + 12 + 30);
+  });
+
+  it('negative score if non-target city and salary < 35k', () => {
+    const job = makeJob({ city: 'Paris', salary: 30000 });
+    // city -5, salary -8, remote +8
+    expect(service.interestScore(job)).toBe(-5 - 8 + 8);
+  });
+
+  it('bonus for InterviewPlanned and OfferMade', () => {
+    const job1 = makeJob({ status: JobStatus.InterviewPlanned });
+    const job2 = makeJob({ status: JobStatus.OfferMade });
+    expect(service.interestScore(job1)).toBe(8 + 6 + 12 + 15); // remote + city + salary + status
+    expect(service.interestScore(job2)).toBe(8 + 6 + 12 + 20);
+  });
+
+  // --- search ---
+  describe('search', () => {
+    beforeEach(async () => {
+      await service.loadJobs();
+    });
+
+    it('returns all jobs if query is empty', () => {
+      expect(service.search('')).toHaveLength(jobsSeed.length);
+    });
+
+    it('filters by title', () => {
+      const res = service.search('vue');
+      expect(res).toHaveLength(1);
+      expect(res[0].title).toMatch(/vue/i);
+    });
+
+    it('filters by city', () => {
+      const res = service.search('saint-étienne');
+      expect(res).toHaveLength(1);
+      expect(res[0].city).toMatch(/saint-étienne/i);
+    });
+
+    it('is case and accent insensitive', () => {
+      expect(service.search('lyon')).toHaveLength(1);
+      expect(service.search('LYON')).toHaveLength(1);
+      expect(service.search('développeur')).toHaveLength(1);
+    });
+  });
+});

--- a/src/services/__tests__/JobsService.spec.ts
+++ b/src/services/__tests__/JobsService.spec.ts
@@ -5,6 +5,7 @@ import { JobLikeState } from '@/models/JobLikeState';
 import { JobStatus } from '@/models/JobStatus';
 import type { JobType } from '@/models/Job.schema';
 import jobsSeed from '../../data/jobs.seed.json';
+import { JobsPersistenceService } from '../JobsPersistenceService';
 
 describe('JobsService', () => {
   let service: JobsService;
@@ -27,34 +28,45 @@ describe('JobsService', () => {
     };
   }
 
+  // --- loadJobs ---
+  describe('loadJobs', () => {
+    it('loads jobs from repo into store', async () => {
+      await service.loadJobs();
+      expect(service['store'].items).toHaveLength(jobsSeed.length);
+      expect(service['store'].items[0]).toHaveProperty('id');
+    });
+  });
+
   // --- interestScore ---
-  it('score = 0 if disliked', () => {
-    const job = makeJob({ like: JobLikeState.Disliked });
-    expect(service.interestScore(job)).toBe(0);
-  });
+  describe('interestScore', () => {
+    it('score = 0 if disliked', () => {
+      const job = makeJob({ like: JobLikeState.Disliked });
+      expect(service.interestScore(job)).toBe(0);
+    });
 
-  it('score = 0 if status is rejected', () => {
-    const job = makeJob({ status: JobStatus.Rejected });
-    expect(service.interestScore(job)).toBe(0);
-  });
+    it('score = 0 if status is rejected', () => {
+      const job = makeJob({ status: JobStatus.Rejected });
+      expect(service.interestScore(job)).toBe(0);
+    });
 
-  it('positive score if remote, target city, salary >= 45k, liked', () => {
-    const job = makeJob({ like: JobLikeState.Liked });
-    // remote +8, city +6, salary +12, liked +30
-    expect(service.interestScore(job)).toBe(8 + 6 + 12 + 30);
-  });
+    it('positive score if remote, target city, salary >= 45k, liked', () => {
+      const job = makeJob({ like: JobLikeState.Liked });
+      // remote +8, city +6, salary +12, liked +30
+      expect(service.interestScore(job)).toBe(8 + 6 + 12 + 30);
+    });
 
-  it('negative score if non-target city and salary < 35k', () => {
-    const job = makeJob({ city: 'Paris', salary: 30000 });
-    // city -5, salary -8, remote +8
-    expect(service.interestScore(job)).toBe(-5 - 8 + 8);
-  });
+    it('negative score if non-target city and salary < 35k', () => {
+      const job = makeJob({ city: 'Paris', salary: 30000 });
+      // city -5, salary -8, remote +8
+      expect(service.interestScore(job)).toBe(-5 - 8 + 8);
+    });
 
-  it('bonus for InterviewPlanned and OfferMade', () => {
-    const job1 = makeJob({ status: JobStatus.InterviewPlanned });
-    const job2 = makeJob({ status: JobStatus.OfferMade });
-    expect(service.interestScore(job1)).toBe(8 + 6 + 12 + 15); // remote + city + salary + status
-    expect(service.interestScore(job2)).toBe(8 + 6 + 12 + 20);
+    it('bonus for InterviewPlanned and OfferMade', () => {
+      const job1 = makeJob({ status: JobStatus.InterviewPlanned });
+      const job2 = makeJob({ status: JobStatus.OfferMade });
+      expect(service.interestScore(job1)).toBe(8 + 6 + 12 + 15); // remote + city + salary + status
+      expect(service.interestScore(job2)).toBe(8 + 6 + 12 + 20);
+    });
   });
 
   // --- search ---
@@ -83,6 +95,24 @@ describe('JobsService', () => {
       expect(service.search('lyon')).toHaveLength(1);
       expect(service.search('LYON')).toHaveLength(1);
       expect(service.search('développeur')).toHaveLength(1);
+      expect(service.search('Développeur')).toHaveLength(1);
+    });
+  });
+
+  // --- setStatus + setLike + persist in localStorage ---
+  describe('setStatus and setLike', () => {
+    it('sets status and persists it', () => {
+      const job = makeJob();
+      service.setStatus(job.id, JobStatus.InterviewPlanned);
+      expect(service['store'].statuses[job.id]).toBe(JobStatus.InterviewPlanned);
+      expect(JobsPersistenceService.loadStatuses()[job.id]).toBe(JobStatus.InterviewPlanned);
+    });
+
+    it('sets like and persists it', () => {
+      const job = makeJob();
+      service.setLike(job.id, JobLikeState.Liked);
+      expect(service['store'].likes[job.id]).toBe(JobLikeState.Liked);
+      expect(JobsPersistenceService.loadLikes()[job.id]).toBe(JobLikeState.Liked);
     });
   });
 });

--- a/src/services/__tests__/JobsService.spec.ts
+++ b/src/services/__tests__/JobsService.spec.ts
@@ -39,6 +39,12 @@ describe('JobsService', () => {
 
   // --- interestScore ---
   describe('interestScore', () => {
+    it('score bonus for Hired', () => {
+      const job = makeJob({ like: JobLikeState.Liked, status: JobStatus.Hired });
+      // like +30, remote +8, city +6, salary +12, hired +30
+      expect(service.interestScore(job)).toBe(30 + 8 + 6 + 12 + 30);
+    });
+
     it('score = 0 if disliked', () => {
       const job = makeJob({ like: JobLikeState.Disliked });
       expect(service.interestScore(job)).toBe(0);

--- a/src/stores/jobs.store.ts
+++ b/src/stores/jobs.store.ts
@@ -1,0 +1,42 @@
+import { reactive, toRefs } from 'vue';
+import { defineStore } from 'pinia';
+import type { JobType } from '@/models/Job.schema';
+import { JobLikeState } from '@/models/JobLikeState';
+import { JobStatus } from '@/models/JobStatus';
+
+interface JobsState {
+  items: JobType[];
+  selectedId: string | null;
+  likes: Record<string, JobLikeState>;
+  statuses: Record<string, JobStatus>;
+}
+
+export const useJobsStore = defineStore('jobs', () => {
+  // --- State ---
+  const state = reactive<JobsState>({
+    items: [],
+    selectedId: null,
+    likes: {},
+    statuses: {},
+  });
+
+  // --- Actions ---
+  function setItems(jobs: JobType[]) {
+    state.items = jobs;
+  }
+
+  function setStatus(jobId: string, status: JobStatus) {
+    state.statuses[jobId] = status;
+  }
+
+  function setLike(jobId: string, like: JobLikeState) {
+    state.likes[jobId] = like;
+  }
+
+  return {
+    ...toRefs(state),
+    setItems,
+    setStatus,
+    setLike,
+  };
+});


### PR DESCRIPTION
This pull request introduces a new `JobsService` layer and a persistent state management system for job likes and statuses. It also adds comprehensive unit tests for the new service and updates the store and seed data to support these features. The main themes are: state management and persistence, business logic for jobs, and test coverage.

**State Management and Persistence**

* Introduced a new Pinia store `useJobsStore` in `jobs.store.ts` to centralize job data, selected job, likes, and statuses, with actions to update these fields.
* Added `JobsPersistenceService` to persist likes and statuses in `localStorage`, providing methods to load and save these mappings.

**Business Logic for Jobs**

* Implemented `JobsService` to encapsulate business logic for jobs, including hydrating state from persistence, loading jobs from the repository, searching, filtering, calculating interest scores, and updating likes/statuses with persistence.

**Test Coverage**

* Added a comprehensive test suite for `JobsService`, covering job loading, interest score calculation, searching, and persistence of likes and statuses.

**Seed Data Update**

* Added two new job entries to `jobs.seed.json` to expand test coverage and available data.