### PR TITLE
10 build shared components

### DIFF
--- a/src/components/DefaultButton.vue
+++ b/src/components/DefaultButton.vue
@@ -1,0 +1,77 @@
+<template>
+  <button
+    :class="[
+      'inline-flex items-center justify-center px-4 py-2 rounded font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2',
+      colorClass,
+      sizeClass,
+      { 'opacity-50 cursor-not-allowed': disabled, 'ring-2 ring-blue-300': active }
+    ]"
+    :disabled="disabled"
+    :type="type"
+    @click="$emit('click', $event)"
+  >
+    <slot />
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed, defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  color: {
+    type: String,
+    default: 'default', // default, success, error, warning
+    validator: (val: string) => ['default', 'success', 'error', 'warning'].includes(val)
+  },
+  size: {
+    type: String,
+    default: 'md', // md, sm, lg
+    validator: (val: string) => ['sm', 'md', 'lg'].includes(val)
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  },
+  active: {
+    type: Boolean,
+    default: false
+  },
+  type: {
+    type: String as () => 'button' | 'submit' | 'reset',
+    default: 'button',
+    validator: (val: string) => ['button', 'submit', 'reset'].includes(val)
+  }
+});
+
+defineEmits(['click']);
+
+const colorClass = computed(() => {
+  switch (props.color) {
+    case 'success':
+      return 'bg-green-600 text-white hover:bg-green-700';
+    case 'error':
+      return 'bg-red-600 text-white hover:bg-red-700';
+    case 'warning':
+      return 'bg-yellow-400 text-gray-900 hover:bg-yellow-500';
+    default:
+      return 'bg-blue-600 text-white hover:bg-blue-700';
+  }
+});
+
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'text-xs px-2 py-1';
+    case 'lg':
+      return 'text-lg px-6 py-3';
+    default:
+      return 'text-base';
+  }
+});
+</script>
+
+<script lang="ts">
+export default {
+  name: 'DefaultButton'
+}
+</script>

--- a/src/components/DefaultButton.vue
+++ b/src/components/DefaultButton.vue
@@ -70,8 +70,3 @@ const sizeClass = computed(() => {
 });
 </script>
 
-<script lang="ts">
-export default {
-  name: 'DefaultButton'
-}
-</script>

--- a/src/components/DislikeButton.vue
+++ b/src/components/DislikeButton.vue
@@ -1,0 +1,49 @@
+<template>
+  <button
+    :aria-pressed="modelValue"
+    :class="[
+      'inline-flex items-center justify-center rounded-full p-2 transition-colors',
+      modelValue ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-400 hover:text-blue-500 hover:bg-blue-50',
+      disabled ? 'opacity-50 cursor-not-allowed' : 'hover:scale-110'
+    ]"
+    @click="toggleDislike"
+    :disabled="disabled"
+    type="button"
+  >
+    <svg v-if="modelValue" class="w-5 h-5 fill-blue-500" viewBox="0 0 20 20">
+      <path d="M16.828 14.828a4 4 0 01-5.656 0L10 13.657l-1.172 1.171a4 4 0 11-5.656-5.656L10 2.343l6.828 6.829a4 4 0 010 5.656z" />
+    </svg>
+    <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M19.682 17.682a4.5 4.5 0 01-6.364 0L12 16.364l-1.318 1.318a4.5 4.5 0 01-6.364-6.364L12 2.636l7.682 7.682a4.5 4.5 0 010 6.364z" />
+    </svg>
+    <span v-if="count !== undefined" class="ml-1 text-xs font-medium">{{ count }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  count: {
+    type: Number,
+    default: undefined
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'dislike', 'undislike']);
+
+function toggleDislike() {
+  if (props.disabled) return;
+  const newValue = !props.modelValue;
+  emit('update:modelValue', newValue);
+  emit(newValue ? 'dislike' : 'undislike');
+}
+</script>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="flex flex-wrap gap-2 items-center w-full">
+    <slot name="filters">
+      <!-- Exemple de filtre par défaut -->
+      <select
+        v-for="(option, idx) in filters"
+        :key="idx"
+        v-model="selected[idx]"
+        class="px-3 py-2 border border-gray-300 rounded-md bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        @change="onFilterChange"
+      >
+        <option :value="null" disabled>Sélectionner</option>
+        <option v-for="item in option" :key="item.value ?? item.label" :value="item.value">
+          {{ item.label }}
+        </option>
+      </select>
+    </slot>
+    <button
+      v-if="showReset"
+      class="ml-2 px-3 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
+      @click="resetFilters"
+    >
+      Réinitialiser
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, defineProps, defineEmits, watch } from 'vue';
+
+interface FilterOption {
+  label: string;
+  value: string | number | null;
+}
+
+const props = defineProps({
+  filters: {
+    type: Array as () => FilterOption[][],
+    default: () => []
+  },
+  modelValue: {
+    type: Array as () => (string | number | null)[],
+    default: () => []
+  },
+  showReset: {
+    type: Boolean,
+    default: true
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'reset']);
+const selected = ref<(string | number | null)[]>([...props.modelValue]);
+
+watch(() => props.modelValue, (val) => {
+  selected.value = [...val];
+});
+
+function onFilterChange() {
+  emit('update:modelValue', [...selected.value]);
+}
+
+function resetFilters() {
+  selected.value = props.filters.map(() => null);
+  emit('update:modelValue', [...selected.value]);
+  emit('reset');
+}
+</script>

--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -2,12 +2,22 @@
   <div class="flex flex-col items-center justify-center min-h-[60vh]">
     <h1 class="text-3xl font-bold text-center mb-4">Bienvenue sur la page d’accueil</h1>
     <h2 class="text-gray-600 text-lg mb-8 text-center">Ceci est le sous-titre de la page d’accueil</h2>
-    <button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors">Bouton de test</button>
+    <button
+      class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
+      @click="goToDemo"
+    >
+      Bouton de test
+    </button>
   </div>
 </template>
 
 <script setup lang="ts">
-// Pas de logique spécifique pour l’instant
+  import { useRouter } from 'vue-router';
+
+  const router = useRouter();
+  function goToDemo() {
+    router.push({ name: 'shared-demo' });
+  }
 </script>
 
 <style scoped>

--- a/src/components/JobCard.vue
+++ b/src/components/JobCard.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="bg-white rounded-lg shadow p-5 flex flex-col gap-3 border border-gray-100 hover:shadow-lg transition-shadow">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <img v-if="companyLogo" :src="companyLogo" alt="Logo" class="w-12 h-12 rounded object-contain bg-gray-50 border border-gray-200" />
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900">{{ title }}</h3>
+          <p class="text-sm text-gray-500">{{ company }}</p>
+        </div>
+      </div>
+      <slot name="actions"></slot>
+    </div>
+    <div class="flex flex-wrap gap-2 items-center">
+      <slot name="badges"></slot>
+      <span v-if="location" class="inline-flex items-center px-2 py-1 bg-gray-100 text-xs text-gray-700 rounded">
+        <svg class="w-4 h-4 mr-1 text-gray-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 21a2 2 0 01-2.828 0l-4.243-4.343a8 8 0 1111.314 0z" />
+          <circle cx="12" cy="11" r="3" />
+        </svg>
+        {{ location }}
+      </span>
+    </div>
+    <div class="text-gray-700 text-sm line-clamp-3">
+      <slot name="description">{{ description }}</slot>
+    </div>
+    <div class="flex items-center justify-between mt-2">
+      <slot name="footer"></slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+
+defineProps({
+  title: { type: String, required: true },
+  company: { type: String, required: true },
+  companyLogo: { type: String, default: '' },
+  location: { type: String, default: '' },
+  description: { type: String, default: '' }
+});
+</script>

--- a/src/components/LikeButton.vue
+++ b/src/components/LikeButton.vue
@@ -1,0 +1,49 @@
+<template>
+  <button
+    :aria-pressed="modelValue"
+    :class="[
+      'inline-flex items-center justify-center rounded-full p-2 transition-colors',
+      modelValue ? 'bg-pink-100 text-pink-600' : 'bg-gray-100 text-gray-400 hover:text-pink-500 hover:bg-pink-50',
+      disabled ? 'opacity-50 cursor-not-allowed' : 'hover:scale-110'
+    ]"
+    @click="toggleLike"
+    :disabled="disabled"
+    type="button"
+  >
+    <svg v-if="modelValue" class="w-5 h-5 fill-pink-500" viewBox="0 0 20 20">
+      <path d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" />
+    </svg>
+    <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 016.364 0L12 7.636l1.318-1.318a4.5 4.5 0 116.364 6.364L12 21.364l-7.682-7.682a4.5 4.5 0 010-6.364z" />
+    </svg>
+    <span v-if="count !== undefined" class="ml-1 text-xs font-medium">{{ count }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  count: {
+    type: Number,
+    default: undefined
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'like', 'unlike']);
+
+function toggleLike() {
+  if (props.disabled) return;
+  const newValue = !props.modelValue;
+  emit('update:modelValue', newValue);
+  emit(newValue ? 'like' : 'unlike');
+}
+</script>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="flex items-center w-full">
+    <input
+      :value="search"
+      type="text"
+      :placeholder="placeholder"
+      class="flex-1 px-4 py-2 border border-gray-300 rounded-l-md focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-gray-900"
+      @input="onInput"
+    />
+    <button
+      class="px-4 py-2 bg-blue-600 text-white rounded-r-md hover:bg-blue-700 transition-colors"
+      @click="onSearch"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z" />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, defineProps, defineEmits } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: ''
+  },
+  placeholder: {
+    type: String,
+    default: 'Rechercher...'
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'search']);
+const search = ref(props.modelValue);
+
+watch(() => props.modelValue, (val) => {
+  search.value = val;
+});
+
+function onInput(e: Event) {
+  const value = (e.target as HTMLInputElement).value;
+  search.value = value;
+  emit('update:modelValue', value);
+}
+
+function onSearch() {
+  emit('search', search.value);
+}
+</script>

--- a/src/components/SharedComponentsDemo.vue
+++ b/src/components/SharedComponentsDemo.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="space-y-8 p-8 bg-gray-50 min-h-screen">
+    <h1 class="text-2xl font-bold mb-6">Démo des composants partagés</h1>
+
+    <section>
+      <h2 class="font-semibold mb-2">SearchBar</h2>
+      <SearchBar v-model="search" placeholder="Rechercher un poste..." @search="onSearch" />
+      <div class="text-xs text-gray-500 mt-1">Valeur : {{ search }}</div>
+    </section>
+
+    <section>
+      <h2 class="font-semibold mb-2 mt-6">FilterBar</h2>
+      <FilterBar v-model="filters" :filters="filterOptions" @reset="onResetFilters" />
+      <div class="text-xs text-gray-500 mt-1">Valeur : {{ filters }}</div>
+    </section>
+
+    <section>
+      <h2 class="font-semibold mb-2 mt-6">JobCard</h2>
+      <JobCard
+        title="Développeur Vue.js"
+        company="TechCorp"
+        companyLogo="https://placehold.co/48x48"
+        location="Paris"
+        description="Rejoignez une équipe dynamique pour développer des applications modernes avec Vue.js et Tailwind CSS."
+      >
+        <template #badges>
+          <StatusBadge status="open" label="Ouvert" />
+          <StatusBadge status="pending" label="En attente" />
+        </template>
+        <template #actions>
+          <LikeButton v-model="liked" :count="12" />
+          <DislikeButton v-model="disliked" :count="2" class="ml-2" />
+        </template>
+        <template #footer>
+          <DefaultButton color="success" size="sm">Postuler</DefaultButton>
+        </template>
+      </JobCard>
+    </section>
+
+    <section>
+      <h2 class="font-semibold mb-2 mt-6">StatusBadge</h2>
+      <div class="flex gap-2">
+        <StatusBadge status="open" label="Ouvert" />
+        <StatusBadge status="closed" label="Fermé" />
+        <StatusBadge status="pending" label="En attente" />
+        <StatusBadge status="draft" label="Brouillon" />
+        <StatusBadge label="Par défaut" />
+      </div>
+    </section>
+
+    <section>
+      <h2 class="font-semibold mb-2 mt-6">LikeButton & DislikeButton</h2>
+      <div class="flex gap-4">
+        <LikeButton v-model="liked" :count="12" />
+        <DislikeButton v-model="disliked" :count="2" />
+      </div>
+    </section>
+
+    <section>
+      <h2 class="font-semibold mb-2 mt-6">DefaultButton</h2>
+      <div class="flex gap-2 flex-wrap">
+        <DefaultButton>Default</DefaultButton>
+        <DefaultButton color="success">Success</DefaultButton>
+        <DefaultButton color="error">Error</DefaultButton>
+        <DefaultButton color="warning">Warning</DefaultButton>
+        <DefaultButton :disabled="true">Disabled</DefaultButton>
+        <DefaultButton :active="true">Active</DefaultButton>
+        <DefaultButton size="sm">Small</DefaultButton>
+        <DefaultButton size="lg">Large</DefaultButton>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import SearchBar from './SearchBar.vue';
+import FilterBar from './FilterBar.vue';
+import JobCard from './JobCard.vue';
+import StatusBadge from './StatusBadge.vue';
+import LikeButton from './LikeButton.vue';
+import DislikeButton from './DislikeButton.vue';
+import DefaultButton from './DefaultButton.vue';
+
+const search = ref('');
+const liked = ref(false);
+const disliked = ref(false);
+const filters = ref([null, null]);
+const filterOptions = [
+  [
+    { label: 'CDI', value: 'cdi' },
+    { label: 'CDD', value: 'cdd' },
+    { label: 'Stage', value: 'stage' }
+  ],
+  [
+    { label: 'Remote', value: 'remote' },
+    { label: 'Présentiel', value: 'onsite' }
+  ]
+];
+
+function onSearch(val: string) {
+  alert('Recherche : ' + val);
+}
+
+function onResetFilters() {
+  filters.value = [null, null];
+}
+</script>

--- a/src/components/StatusBadge.vue
+++ b/src/components/StatusBadge.vue
@@ -1,0 +1,35 @@
+<template>
+  <span :class="badgeClass">
+    <slot>{{ label }}</slot>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed, defineProps } from 'vue';
+
+const statusColors: Record<string, string> = {
+  open: 'bg-green-100 text-green-800',
+  closed: 'bg-red-100 text-red-800',
+  pending: 'bg-yellow-100 text-yellow-800',
+  draft: 'bg-gray-100 text-gray-700',
+  default: 'bg-blue-100 text-blue-800'
+};
+
+const props = defineProps({
+  status: {
+    type: String,
+    default: 'default'
+  },
+  label: {
+    type: String,
+    default: ''
+  }
+});
+
+const badgeClass = computed(() => {
+  return [
+    'inline-flex items-center px-2 py-1 rounded text-xs font-medium',
+    statusColors[props.status] || statusColors.default
+  ].join(' ');
+});
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,6 +17,11 @@ const router = createRouter({
       // which is lazy-loaded when the route is visited.
       component: () => import('../views/AboutView.vue'),
     },
+    {
+      path: '/shared-demo',
+      name: 'shared-demo',
+      component: () => import('../components/SharedComponentsDemo.vue'),
+    },
   ],
 })
 


### PR DESCRIPTION
This pull request introduces a comprehensive set of new shared UI components to the codebase, including buttons, badges, cards, and filter/search bars, along with a demonstration page to showcase their usage. It also updates the homepage button to navigate to the new demo page and registers the demo page in the router. These additions lay the groundwork for a consistent, reusable component library across the application.

**New shared UI components:**

* Added `DefaultButton.vue` for a customizable button with color, size, disabled, and active states.
* Added `LikeButton.vue` and `DislikeButton.vue` for interactive like/dislike actions with count display and accessibility features. [[1]](diffhunk://#diff-c538ce847ede6dbd5675451c9ac4a3ba2066b13409bff6585a847d30516de41cR1-R49) [[2]](diffhunk://#diff-818ab17c1c6056453f46aaf8372c8c99b49006d15ef76925e16b08edad288e32R1-R49)
* Added `StatusBadge.vue` for displaying status indicators with different color schemes.
* Added `JobCard.vue` for displaying job information with slots for badges, actions, and footer content.
* Added `SearchBar.vue` and `FilterBar.vue` for searching and filtering lists, supporting two-way binding and reset functionality. [[1]](diffhunk://#diff-6ab8b9109e380c819c024ff295c4528f3b08843dcbbaf1d8dceb78b3a55fa626R1-R51) [[2]](diffhunk://#diff-f4672e2a48acc4fa5326e7bb7c024bcc9da2b9dc9192970001f0646c840016c7R1-R67)

**Demo and integration:**

* Added `SharedComponentsDemo.vue` as a showcase page for all new shared components, demonstrating their appearance and interactive behavior.
* Registered the `/shared-demo` route in the application router to access the demo page.
* Updated the homepage button in `HomePage.vue` to navigate to the new shared components demo page.